### PR TITLE
게시판 API 만들기 - Data Rest 적용 및 테스트 정의

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -24,6 +24,8 @@ repositories {
 }
 
 dependencies {
+    implementation 'org.springframework.boot:spring-boot-starter-data-rest'
+    implementation 'org.springframework.data:spring-data-rest-hal-explorer'
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
     runtimeOnly 'com.h2database:h2'
     runtimeOnly 'com.mysql:mysql-connector-j'

--- a/src/main/java/com/fastcampus/board/domain/Article.java
+++ b/src/main/java/com/fastcampus/board/domain/Article.java
@@ -16,7 +16,7 @@ import java.util.Set;
         @Index(columnList = "title"),
         @Index(columnList = "hashtag"),
         @Index(columnList = "createdAt"),
-        @Index(columnList = "createBy")
+        @Index(columnList = "createdBy")
 })
 @Entity
 public class Article extends AuditingFields {

--- a/src/main/java/com/fastcampus/board/repository/ArticleCommentRepository.java
+++ b/src/main/java/com/fastcampus/board/repository/ArticleCommentRepository.java
@@ -2,6 +2,8 @@ package com.fastcampus.board.repository;
 
 import com.fastcampus.board.domain.ArticleComment;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.rest.core.annotation.RepositoryRestResource;
 
+@RepositoryRestResource
 public interface ArticleCommentRepository extends JpaRepository<ArticleComment, Long> {
 }

--- a/src/main/java/com/fastcampus/board/repository/ArticleRepository.java
+++ b/src/main/java/com/fastcampus/board/repository/ArticleRepository.java
@@ -2,6 +2,8 @@ package com.fastcampus.board.repository;
 
 import com.fastcampus.board.domain.Article;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.rest.core.annotation.RepositoryRestResource;
 
+@RepositoryRestResource
 public interface ArticleRepository extends JpaRepository<Article, Long> {
 }

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -20,3 +20,6 @@ spring:
       hibernate.format_sql: true
       hibernate.default_batch_fetch_size: 100
   sql.init.mode: always
+  data.rest:
+    base-path: /api
+    detection-strategy: annotated

--- a/src/test/java/com/fastcampus/board/controller/DataRestTest.java
+++ b/src/test/java/com/fastcampus/board/controller/DataRestTest.java
@@ -1,0 +1,72 @@
+package com.fastcampus.board.controller;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.transaction.annotation.Transactional;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@DisplayName("Data Rest API Test")
+@Transactional
+@AutoConfigureMockMvc
+@SpringBootTest
+public class DataRestTest {
+
+    private final MockMvc mvc;
+
+    public DataRestTest(@Autowired MockMvc mvc) {
+        this.mvc = mvc;
+    }
+
+    @DisplayName("[api] 게시글 리스트 조회")
+    @Test
+    void selectArticles() throws Exception {
+        // given
+
+        // when & then
+        mvc.perform(get("/api/articles"))
+                .andExpect(status().isOk())
+                .andExpect(content().contentType(MediaType.valueOf("application/hal+json")));
+    }
+
+    @DisplayName("[api] 게시글 단건 조회")
+    @Test
+    void selectArticle() throws Exception {
+        // given
+
+        // when & then
+        mvc.perform(get("/api/articles/1"))
+                .andExpect(status().isOk())
+                .andExpect(content().contentType(MediaType.valueOf("application/hal+json")));
+    }
+
+    @DisplayName("[api] 게시글 -> 댓글 리스트 조회")
+    @Test
+    void selectArticleCommentsFromArticle() throws Exception {
+        // given
+
+        // when & then
+        mvc.perform(get("/api/articleComments"))
+                .andExpect(status().isOk())
+                .andExpect(content().contentType(MediaType.valueOf("application/hal+json")));
+    }
+
+    @DisplayName("[api] 게시글 -> 댓글 단건 조회")
+    @Test
+    void selectArticleCommentFromArticle() throws Exception {
+        // given
+
+        // when & then
+        mvc.perform(get("/api/articleComments/1"))
+                .andExpect(status().isOk())
+                .andExpect(content().contentType(MediaType.valueOf("application/hal+json")));
+    }
+
+}


### PR DESCRIPTION
게시글, 댓글 데이터는 간편하게 Spring Data Rest 로 서비스하고, 해당 API 들의 존재 여부만 체크하게끔 통합테스트 작성